### PR TITLE
#2 CI for operating systems and Codecov support

### DIFF
--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -25,7 +25,7 @@ jobs:
         python -m pip install .[dev]
     - name: Run Codecov
       run: |
-        pytest --cov-config=.coveragerc --cov=./ci_course --cov-branch --cov-report=xml
+        pytest --cov=./pkmodel --cov-branch --cov-report=xml
         cat coverage.xml
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -1,0 +1,43 @@
+name: codecov
+
+on:
+  push:
+    branches: [ "master","CI" ]
+  pull_request:
+    branches: [ "**" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python "3.12"
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.12"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install .[dev]
+    - name: Run Codecov
+      run: |
+        pytest --cov-config=.coveragerc --cov=./ci_course --cov-branch --cov-report=xml
+        cat coverage.xml
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+        files: coverage.xml
+    
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/os_versions.yaml
+++ b/.github/workflows/os_versions.yaml
@@ -1,0 +1,36 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
+
+name: Operating systems
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install .[dev]
+      - name: Lint with flake8
+        run: |
+          flake8
+      - name: Test with pytest
+        run: |
+          pytest

--- a/.github/workflows/os_versions.yaml
+++ b/.github/workflows/os_versions.yaml
@@ -5,9 +5,9 @@ name: Operating systems
 
 on:
   push:
-    branches: ["main","CI"]
+    branches: ["master","CI"]
   pull_request:
-    branches: ["main","CI"]
+    branches: ["**"]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/os_versions.yaml
+++ b/.github/workflows/os_versions.yaml
@@ -5,9 +5,9 @@ name: Operating systems
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main","CI"]
   pull_request:
-    branches: ["main"]
+    branches: ["main","CI"]
   workflow_dispatch:
 
 jobs:

--- a/prototype.py
+++ b/prototype.py
@@ -2,8 +2,10 @@ import matplotlib.pylab as plt
 import numpy as np
 import scipy.integrate
 
+
 def dose(t, X):
     return X
+
 
 def rhs(t, y, Q_p1, V_c, V_p1, CL, X):
     q_c, q_p1 = y
@@ -11,6 +13,7 @@ def rhs(t, y, Q_p1, V_c, V_p1, CL, X):
     dqc_dt = dose(t, X) - q_c / V_c * CL - transition
     dqp1_dt = transition
     return [dqc_dt, dqp1_dt]
+
 
 model1_args = {
     'name': 'model1',

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,11 @@ def get_version():
     """
     Get version number from the pkmodel module.
 
-    The easiest way would be to just ``import pkmodel ``, but note that this may
-    fail if the dependencies have not been installed yet. Instead, we've put
-    the version number in a simple version_info module, that we'll import here
-    by temporarily adding the oxrse directory to the pythonpath using sys.path.
+    The easiest way would be to just ``import pkmodel ``, but note that this
+    may fail if the dependencies have not been installed yet. Instead, we've
+    put the version number in a simple version_info module, that we'll import
+    here by temporarily adding the oxrse directory to the pythonpath using 
+    sys.path.
     """
     import os
     import sys

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def get_version():
     The easiest way would be to just ``import pkmodel ``, but note that this
     may fail if the dependencies have not been installed yet. Instead, we've
     put the version number in a simple version_info module, that we'll import
-    here by temporarily adding the oxrse directory to the pythonpath using 
+    here by temporarily adding the oxrse directory to the pythonpath using
     sys.path.
     """
     import os

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,9 @@ setup(
         'dev': [
             # Flake8 for code style checking
             'flake8>=3',
+            # pytest and pytest-cov for continuous integration
+            'pytest',
+            'pytest-cov',
         ],
     },
 )


### PR DESCRIPTION
Added .yaml files to run unit tests with pytest for different operating systems, and for Codecov analysis of the pkmodel folder. Also fixed syntax errors identified by flake in the prototype.py and setup.py scripts. CI should trigger from a pull request from any branch, or a push request to the 'master' or 'CI' branch.